### PR TITLE
gx: update go-datastore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.2: QmSb95iHExSSb47zpmyn5CyY5PZidVWSjyKyDqgYQrnKor
+1.2.3: QmU7tt6mHJ5Wocjy2omBxpDfN8g9pkRimzJae7EXdrs96k

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG",
+      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
       "name": "go-datastore",
-      "version": "1.2.2"
+      "version": "1.4.0"
     }
   ],
   "gxVersion": "0.8.0",
@@ -25,6 +25,6 @@
   "license": "",
   "name": "go-ds-measure",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/whyrusleeping/failstore/pull/5
- https://github.com/whyrusleeping/retry-datastore/pull/4
- https://github.com/ipfs/go-ds-flatfs/pull/24


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace